### PR TITLE
Add a backend for timestats

### DIFF
--- a/src/Benign.hs
+++ b/src/Benign.hs
@@ -42,6 +42,7 @@ module Benign
     SeqIsEval,
     NF (..),
     EvalIO (..),
+    PureEval (..),
   )
 where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,7 @@ resolver: nightly-2022-10-30
 packages:
   - .
   - katip
+  - timestats
+
+extra-deps:
+  - timestats-0.1.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: timestats-0.1.0@sha256:86677d16269df53fb44d1aa8e90bfd6503461d637ff3d914f30b1d4ce98da5d2,1284
+    pantry-tree:
+      sha256: ae05a6e3b2fdb99eaae6b465c00a5bfbb525d6b7cb5839e685eb38c4c0ed1394
+      size: 277
+  original:
+    hackage: timestats-0.1.0
 snapshots:
 - completed:
     sha256: eca327fb42f0942a994c95e8765e11ba6c416a6e73251745b480e207b9c6c274

--- a/timestats/benign-timestats.cabal
+++ b/timestats/benign-timestats.cabal
@@ -1,0 +1,32 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           benign-timestats
+version:        0.1.0
+synopsis:       A library for benign effects
+description:    see README.md.
+homepage:       https://github.com/aspiwack/haskell-benign#readme
+bug-reports:    https://github.com/aspiwack/haskell-benign/issues
+author:         Arnaud Spiwack
+maintainer:     arnaud@spiwack.net
+copyright:      MIT
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/aspiwack/haskell-benign
+
+library
+  exposed-modules:
+      Benign.TimeStats
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances -Wredundant-constraints
+  build-depends:
+      base
+    , benign
+    , timestats
+  default-language: Haskell2010

--- a/timestats/package.yaml
+++ b/timestats/package.yaml
@@ -1,0 +1,21 @@
+name: benign-timestats
+version: 0.1.0
+author: Arnaud Spiwack
+maintainer: arnaud@spiwack.net
+github: aspiwack/haskell-benign
+copyright: MIT
+synopsis: A library for benign effects
+description: see README.md.
+
+dependencies:
+  - base
+  - benign
+  - timestats
+
+ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances -Wredundant-constraints
+
+library:
+  source-dirs: src
+  when:
+  - condition: false
+    other-modules: Paths_benign_timestats # substitute name with the package name

--- a/timestats/src/Benign/TimeStats.hs
+++ b/timestats/src/Benign/TimeStats.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE GHC2021 #-}
+
+module Benign.TimeStats where
+
+import Benign qualified
+import Debug.TimeStats qualified as TimeStats
+import System.IO.Unsafe (unsafePerformIO)
+
+measure :: Benign.Eval a => String -> a -> Benign.Result a
+measure label thing = unsafePerformIO $ TimeStats.measureM label $ Benign.evalIO (Benign.PureEval thing)
+{-# NOINLINE measure #-}


### PR DESCRIPTION
This one is so small, I feel silly to have made a package just for it. The `package.yaml` is bigger than the Haskell code! Timestats already has support for pure code, but doesn't support evaluation strategies. So this is just _one_ function to measure the time for a call to `eval`.