### PR TITLE
Completely redesign the API around explicit strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,27 +24,26 @@ The Benign library is an attempt to address this gap. A difficulty is
 laziness. With laziness, things have a beginning (when the thunk is
 being forced), but not a well-defined end. So what do we measure the
 time of? The solution of the Benign library is to be less lazy. We
-keep laziness for algorithms, but use strict (or at least stricter)
-types to assemble bigger steps. It's fine to log or trace in pure
-code, since we don't consider that these observations are part of the
-semantics of the program.
+keep laziness for algorithms, but use evaluate more strictly when
+assembling bigger steps. It's fine to log or trace in pure code, since
+we don't consider that these observations are part of the semantics of
+the program.
 
 The Benign library provides facilities to create benign effects,
-including to use strict types to assemble these large steps.
+including evaluation strategies to express precisely how strict we
+want to be.
 
 The premise underlying all this, as well as the implementation of the
 library, is that logging or tracing is not very fast. So we don't want
 to log or trace in places where performance is really essential. This
 is why at the most inner level, where tight loops and algorithms live,
 laziness is not a problem: we are not going to log there, this would
-cost too much performance. At a more outer level, we can use
-strictness to make steps with a beginning and an end. It's ok if there
-is a cost in terms of conversion, this is not where we need to
-optimise too much. The library can, and does, prevent optimisation
-through its functions (note that cost-centre profiling also prevents
-optimisation through cost centres; it isn't surprising that we are
-having a similar problem). With the optimisation not working at that
-level, strictness is much less of a problem.
+cost too much performance. The library can, and does, prevent
+optimisation through its functions anyway (note that cost-centre
+profiling also prevents optimisation through cost centres; it isn't
+surprising that we are having a similar problem). So benign effects
+all must happen at rather macro steps, where we don't have to worry
+too much about the impact of evaluation.
 
 ## Backends
 

--- a/backends/timestats/src/Benign/TimeStats.hs
+++ b/backends/timestats/src/Benign/TimeStats.hs
@@ -3,9 +3,10 @@
 module Benign.TimeStats where
 
 import Benign qualified
+import Control.Exception
 import Debug.TimeStats qualified as TimeStats
 import System.IO.Unsafe (unsafePerformIO)
 
-measure :: Benign.Eval a => String -> a -> Benign.Result a
-measure label thing = unsafePerformIO $ TimeStats.measureM label $ Benign.evalIO (Benign.PureEval thing)
+measure :: String -> Benign.Strat a -> a -> a
+measure label strat thing = unsafePerformIO $ TimeStats.measureM label $ do Benign.E <- evaluate (strat thing); return thing
 {-# NOINLINE measure #-}

--- a/benign.cabal
+++ b/benign.cabal
@@ -34,7 +34,6 @@ library
     , containers
     , deepseq
     , stm
-    , strict-wrapper
     , transformers
   default-language: Haskell2010
 
@@ -50,6 +49,5 @@ executable simple-print
     , containers
     , deepseq
     , stm
-    , strict-wrapper
     , transformers
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,6 @@ dependencies:
   - containers
   - deepseq
   - stm
-  - strict-wrapper
   - transformers
 
 ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wnoncanonical-monad-instances -Wredundant-constraints

--- a/src/Benign/GhcEventsAnalyze.hs
+++ b/src/Benign/GhcEventsAnalyze.hs
@@ -12,7 +12,7 @@ module Benign.GhcEventsAnalyze where
 import Benign qualified
 import Debug.Trace (traceEventIO)
 
-event :: Benign.Eval a => String -> a -> Benign.Result a
+event :: String -> Benign.Strat a -> a -> a
 event event_name =
   Benign.unsafeSpanBenign
     (traceEventIO $ "START " ++ event_name)


### PR DESCRIPTION
The API is much nicer. Type families in the `Eval` type class were getting in the way of derivation (derivation isn't done yet). It just created a lot of boiler place. Both at call sites where we had to wrap random values in a newtype all the time, and when defining `Eval` instances (which may be used just once, which was entirely unnecessary), since the instances were almost entirely boilerplate.

This actually deletes lines of code, so even the implementation is simpler really. I don't need some special support for the `strict-wrapper` library: just use the `seq` strategy.

This is looking quite good.

Closes #7.
Closes #17.